### PR TITLE
Updated gem bundler to version 1.3 and fixed version checking

### DIFF
--- a/kitchenplan
+++ b/kitchenplan
@@ -65,7 +65,7 @@ end.parse!
 
 # Bootstrapping dependencies
 
-unless system("(gem spec bundler -v '~> 1.2.0' > /dev/null 2>&1) || sudo gem install bundler --no-rdoc --no-ri")
+unless system("(gem spec bundler -v '~> 1.3.0' > /dev/null 2>&1) || sudo gem install bundler -v '~> 1.3.0' --no-rdoc --no-ri")
     abort "Failed to install bundler"
 end
 


### PR DESCRIPTION
Script checks form gem bundler version 1.2 but then installs latest bundler version which is 1.3.6 so the gem will get reinstalled on every ./kitchenplan run. This pull fixes the error and updates bundler to 1.3.x version.
