### PR TITLE
Fixed bootstraping for Fedora/RedHat/CentOS using Yum.

### DIFF
--- a/kitchenplan
+++ b/kitchenplan
@@ -53,8 +53,17 @@ end.parse!
 
 # Bootstrapping dependencies
 
-unless system("(gem spec bundler -v > /dev/null 2>&1) || sudo gem install bundler --no-rdoc --no-ri")
-    abort "Failed to install bundler"
+if File.exist? '/etc/redhat-release'
+    unless system("(gem spec -q bundler > /dev/null 2>&1) || sudo yum install -y rubygem-bundler")
+        abort "Failed to install bundler"
+    end
+    unless system("(rpm -qi ruby-devel > /dev/null 2>&1) || sudo yum install -y ruby-devel")
+        abort "Failed to install ruby-devel"
+    end
+else
+    unless system("(gem spec bundler -v > /dev/null 2>&1) || sudo gem install bundler --no-rdoc --no-ri")
+        abort "Failed to install bundler"
+    end
 end
 
 bundle_command = ["sudo", "bundle"]


### PR DESCRIPTION
This will bootstrap _Fedora/RedHat/CentOS_ and derivatives using `yum install rubygem-bundler ruby-devel`. This will prevent some load_path problems when using `gem install bundler`.

**For Information**: A lot of recipes used in the default configurations fails on _Fedora_ or does nothing.
