### PR TITLE
add `go` script to install/update kitchenplan (inspired by homebrew)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If the repo for your organisation is private, continue with setting up your SSH 
 The `KITCHENPLAN_REPO` environment variable can be set before installation to customize what git repository is used for kitchen plan.
 
 ```bash
-$ export KITCHENPLAN_REPO=https://github.com/mycompany/kitchenplan
+$ export KITCHENPLAN_REPO=https://github.com/mycompany/kitchenplan.git
 $ ruby -e "$(curl -fsSL https://raw.github.com/kitchenplan/kitchenplan/master/go)"
 ```
 

--- a/go
+++ b/go
@@ -11,7 +11,7 @@
 #
 # execution can be customized by the following environmental variables:
 # KITCHENPLAN_PATH - kitchenplan installation path (defaults to /opt/kitchenplan)
-# KITCHENPLAN_REPO - repository to use for recipes/cookbooks (defaults to https://github.com/kitchenplan/kitchenplan)
+# KITCHENPLAN_REPO - repository to use for recipes/cookbooks (defaults to https://github.com/kitchenplan/kitchenplan.git)
 
 KITCHENPLAN_PATH = ENV.fetch("KITCHENPLAN_PATH", "/opt/kitchenplan")
 KITCHENPLAN_REPO = ENV.fetch("KITCHENPLAN_REPO", "https://github.com/kitchenplan/kitchenplan.git")


### PR DESCRIPTION
installation script modeled after homebrew to automate setup and updating of kitchenplan.

supports custom forks of kitchenplan via environment variables.

example execution:

``` bash
# (optional) use a custom kitchenplan repository
$ export KITCHENPLAN_REPO=https://github.com/mycompany/kitchenplan.git

# install/update kitchenplan recipes and run chef
 $ ruby -e "$(curl -fsSL https://raw.github.com/kitchenplan/kitchenplan/master/go)"
```

see updated README + go script for additional documentation.
