### PR TITLE
Fix defect with groups of groups

### DIFF
--- a/lib/kitchenplan/config.rb
+++ b/lib/kitchenplan/config.rb
@@ -37,8 +37,8 @@ module Kitchenplan
         @people_config = ( YAML.load(ERB.new(File.read(people_config_path)).result) if File.exist?(people_config_path) ) || YAML.load(ERB.new(File.read("config/people/roderik.yml")).result)
     end
 
-    def parse_group_configs(group = @people_config['groups'])
-        @group_configs = {}
+    def parse_group_configs(group = @default_config['groups'] | @people_config['groups'])
+        @group_configs = @group_configs || {}
         defined_groups = group || []
         defined_groups.each do |group|
             self.parse_group_config(group)


### PR DESCRIPTION
@roderik,

I unintentionally introduced a defect causing some parsed groups to be overridden. This pull request fixes and also allows the default.yml to contain groups.
- Ensure @groups_configs is not redefined
- Added support @default_config['groups']
