### PR TITLE
Merge @default_config['groups'] with @people_config['groups']

### DIFF
--- a/lib/kitchenplan/config.rb
+++ b/lib/kitchenplan/config.rb
@@ -37,7 +37,7 @@ module Kitchenplan
         @people_config = ( YAML.load(ERB.new(File.read(people_config_path)).result) if File.exist?(people_config_path) ) || YAML.load(ERB.new(File.read("config/people/roderik.yml")).result)
     end
 
-    def parse_group_configs(group = @default_config['groups'] || @people_config['groups'])
+    def parse_group_configs(group = (( @default_config['groups'] || [] ) | ( @people_config['groups'] || [] )))
         @group_configs = @group_configs || {}
         defined_groups = group || []
         defined_groups.each do |group|


### PR DESCRIPTION
@roderik

Thanks for fixing the `|` issue.

My original intention was to combine both the `default_config` groups if found with the `people_config` groups, but I realise now this would have caused failure if default_config['groups'] was not defined.

Fortunately this issue was spotted when you merged the original change in and Array.union was replaced with an || condition.

This pull request restores the behaviour I originally intended. 

Now might be a good time to introduce some unit tests. Happy to look into this.
