### PR TITLE
Added support to create <username>.yml if it doesn't exist when using a config repo

### DIFF
--- a/lib/kitchenplan/cli.rb
+++ b/lib/kitchenplan/cli.rb
@@ -1,3 +1,4 @@
+
 require 'thor'
 
 module Kitchenplan
@@ -17,6 +18,12 @@ module Kitchenplan
           fetch(gitrepo, targetdir)
         else
           create(targetdir)
+        end
+      end
+      unless File.exists?("#{targetdir}/kitchenplan/config/people/#{ENV['USER']}.yml")
+        user_create = yes?("config/people/#{ENV['USER']}.yml does not exist. Do you wish to create it? [y,n]", :green)
+        if user_create
+          create_user(targetdir)
         end
       end
     end
@@ -145,6 +152,19 @@ module Kitchenplan
         end
 
         print_notice("Now start editing the config files in #{targetdir}/kitchenplan/config, push them to a git server and run 'kitchenplan provision'")
+      end
+
+      def create_user(targetdir)
+        print_step("Creating #{ENV['USER']}.yml config")
+
+        template('user.yml.erb', "#{targetdir}/kitchenplan/config/people/#{ENV['USER']}.yml")
+
+        inside("#{targetdir}/kitchenplan") do
+          dorun("git add -A config/people/#{ENV['USER']}.yml")
+          dorun("git commit -q -m 'Initial commit for user #{ENV['USER']}'")
+        end
+
+        print_notice("Now start editing #{ENV['USER']}.yml in #{targetdir}/kitchenplan/config/people, and push it to a git server and run 'kitchenplan provision'")
       end
 
       def install_bundler(targetdir)

--- a/lib/kitchenplan/config.rb
+++ b/lib/kitchenplan/config.rb
@@ -35,7 +35,7 @@ module Kitchenplan
 
     def parse_people_config
       people_config_path = "config/people/#{Etc.getlogin}.yml"
-      @people_config = (YAML.load(ERB.new(File.read(people_config_path)).result) if File.exist?(people_config_path)) || YAML.load(ERB.new(File.read('config/people/roderik.yml')).result)
+      @people_config = (YAML.load(ERB.new(File.read(people_config_path)).result) if File.exist?(people_config_path)) || {}
     end
 
     def parse_group_configs(group = (( @default_config['groups'] || [] ) | ( @people_config['groups'] || [] )))


### PR DESCRIPTION
@roderik,

This change removes the dependency on explicitly having `people/<username>.yml` and it's fallback `roderik.yml`.

Given that `default.yml` is considered as part of config resolution some users may opt to only add configuration into this file. This scenario would generally be for single user who doesn't have a need to manage multiple users.

In a multi-user scenario, `defaults.yml` could still be applied but having `roderik.yml` as a fallback would cause an error if it didn't exists in the custom config repo.

Also as part of this change, the user is now prompted to create a user config file if it doesn't already exist when using a config repo.

If they decide to create <username>.yml, a new branch is created `people/<username>` and any config changes are committed here.

A user can then push their branch, allowing the option in the future for it to be merged into master.

The next time a user needs to provision a machine they then have two options.

1) Specify a branch for the config repo

``` bash
Please enter the clone URL of your git config repository: --branch people/<username> https://(host)/(org|username)/kitchenplan-config.git
```

eg:

``` bash
Please enter the clone URL of your git config repository: --branch people/indieisaconcept https://github.com/indieisaconcept/kitchenplan-config.git
```

or

2) Specify a vanilla config repo url
