### PR TITLE
Fixes go script when checking out version2

### DIFF
--- a/go
+++ b/go
@@ -162,8 +162,8 @@ else
   sudo "mkdir -p #{KITCHENPLAN_PATH}"
   sudo "chown -R #{ENV["USER"]} #{KITCHENPLAN_PATH}"
   normaldo "git clone -q #{KITCHENPLAN_REPO} #{KITCHENPLAN_PATH}"
+  Dir.chdir KITCHENPLAN_PATH
   normaldo "git checkout version2"
 end
 
-Dir.chdir KITCHENPLAN_PATH if options[:interaction]
 normaldo "./kitchenplan #{options[:interaction] ? '': '-d'}"


### PR DESCRIPTION
Changes directory to KITCHENPLAN_PATH prior to calling "git checkout version2"
