### PR TITLE
Fix require of gabba gem's case for case sensitive file systems

### DIFF
--- a/lib/kitchenplan/cli.rb
+++ b/lib/kitchenplan/cli.rb
@@ -108,7 +108,7 @@ module Kitchenplan
 
       def send_ping
         print_step('Sending a ping to Google Analytics')
-        require 'Gabba'
+        require 'gabba'
         Gabba::Gabba.new('UA-46288146-1', 'github.com').event('Kitchenplan', 'Run', ENV['USER'])
       end
 


### PR DESCRIPTION
On a filesystem with case-sensitivity turned on, kitchen plan fails due to a "require 'Gabba'" which should read "require 'gabba'".
