### PR TITLE
Strip newline from output of one command before feeding it to another

### DIFF
--- a/lib/kitchenplan/cli.rb
+++ b/lib/kitchenplan/cli.rb
@@ -203,6 +203,7 @@ module Kitchenplan
           dorun('touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress')
           prod = dorun('softwareupdate -l | grep -B 1 "Developer" | head -n 1 | awk -F"*" \'{print $2}\'', true)
           dorun("softwareupdate -i #{prod.chomp} -v")
+          dorun("sudo xcodebuild -license")
         else
           dmg = nil
           if osx_ver == 7


### PR DESCRIPTION
On my computer at least, the return value from line 204 ends in a newline. When interpolated into the string on line 205, it results in:
- the `-v` flag not being passed to `softwareupdate`; and
- a (harmless) error when `dorun` tries to execute `-v` by itself.
