### PR TITLE
Added hardware model detection for configurations

### DIFF
--- a/lib/kitchenplan/config.rb
+++ b/lib/kitchenplan/config.rb
@@ -3,7 +3,6 @@ require 'etc'
 #require 'ohai'
 require 'erb'
 require 'deep_merge'
-require 'thor'
 
 module Kitchenplan
 


### PR DESCRIPTION
I provisioned a MacBook Air and Mac Pro short after each other with the same kitchenplan config. Since the hostname got set by attributes they got the same hostname. 

I modified the code that it will check in the system folder for a system specific YAML-file, like `config/system/MacPro3,1.yml` to allow different attributes per hardware-model.

My darwin shell knowledge is limited so I guess the command to retrieve the hardware model could be improved (see line 34).
