### PR TITLE
Fix the version check to support OS X 10.10

### DIFF
--- a/lib/kitchenplan/platform/mac_os_x.rb
+++ b/lib/kitchenplan/platform/mac_os_x.rb
@@ -38,7 +38,7 @@ class Kitchenplan
       # is this version of the platform supported by the kitchenplan codebase?
       def version_supported?
 	Kitchenplan::Log.debug "#{self.class} : Is platform version lower than #{@lowest_version_supported}?"
-	return false if self.version.to_s <  @lowest_version_supported
+	return false if Gem::Version.new(self.version.to_s) <  Gem::Version.new(@lowest_version_supported)
 	true
       end
       # is the user part of the admin group?


### PR DESCRIPTION
Fix the OS X version check by using Gem::Version.new instead of string comparaison
