### PR TITLE
Add no fetch option to provision

### DIFF
--- a/lib/kitchenplan/cli.rb
+++ b/lib/kitchenplan/cli.rb
@@ -38,14 +38,14 @@ module Kitchenplan
     option 'no-fetch', :type => :boolean
     option :recipes, :type => :array
     option :solorb, :type => :string, :default => 'tmp/solo.rb'
-    desc 'provision [<target directory>] [--debug] [--recipes=x y z] [--solorb=path]', 'Provision your workstation with Kitchenplan'
+    desc 'provision [<target directory>] [--debug] [--recipes=x y z] [--solorb=path] [--no-fetch]', 'Provision your workstation with Kitchenplan'
     long_desc <<-LONGDESC
     `kitchenplan provision` will use the configuration in /opt/kitchenplan (or <target directory>
     if you pass it along) to provision your workstation using Chef.
 
     You can optionally pass --debug to see more detail of what's happening.
 
-    Passing --no-fetch will skip updating the librarian sources from remote.
+    Passing --no-fetch will skip updating the librarian sources from remote sources.
 
     If you just want to install a few recipes pass them along with --recipes and it will override the run list (not the attributes!)
     LONGDESC


### PR DESCRIPTION
While hacking on my local kitchenplan configs, I realized that if I skip the librarian-update, provisioning would go much faster. 

I'm using this with `kitchenplan provision --recipes=provision::home --no-fetch` now, and development is going much faster now as I am locally developing my recipes.

I'm happier hacking with the --no-fetch option, but this may be a special case. Cheers
