### PR TITLE
Don't ping google analytics

### DIFF
--- a/lib/kitchenplan/cli.rb
+++ b/lib/kitchenplan/cli.rb
@@ -53,7 +53,6 @@ module Kitchenplan
       logo
       prepare_folders(targetdir)
       install_bundler(targetdir)
-      send_ping
       recipes = parse_config(targetdir)
       fetch_cookbooks(targetdir, options[:debug]) unless options['no-fetch']
       run_chef(targetdir, (options[:recipes] ? options[:recipes] : recipes), options[:solorb], options[:debug])
@@ -108,12 +107,6 @@ module Kitchenplan
           end
           return config.config['recipes']
         end
-      end
-
-      def send_ping
-        print_step('Sending a ping to Google Analytics')
-        require 'gabba'
-        Gabba::Gabba.new('UA-46288146-1', 'github.com').event('Kitchenplan', 'Run', ENV['USER'])
       end
 
       def fetch(gitrepo, targetdir)


### PR DESCRIPTION
We shouldn't be pinging Google Analytics with every person's Kitchenplan runs all the time. This is a problem for several reasons:
1. Security: Organizations and individuals shouldn't be reporting what their activities are to some central authority.
2. Performance: This requires a connection to the internet and is a performance hit.
3. This also just isn't the place something like this belongs. If your organization requires you to report and track this sort of thing, then do it yourself in your default.yml in your config repository for Kitchenplan.
